### PR TITLE
Change seeds to contact points in doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ khronus {
   # http port where Khronus will be listening for queries, posting & other stuff
   # port = 8400
 
-  # comma-delimited list of Cassandra seeds
+  # comma-delimited list of Cassandra nodes to use as intial contact points (the rest of the Cassandra nodes will be discovered)
   cassandra.cluster.seeds = "127.0.0.1"
 }
 


### PR DESCRIPTION
I can rename the property in the config and code if you'd prefer changing it initially in the documenting comment. 

Calling this the cassandra seeds is confusing as it doesn't need to be the actual cassandra seeds (they are only used for bootstrapping new nodes). It can be any cassandra nodes and the other nodes will be discovered by the client.
